### PR TITLE
fix: 从umi获取语言信息

### DIFF
--- a/packages/xgen/services/app.ts
+++ b/packages/xgen/services/app.ts
@@ -4,15 +4,17 @@ import store from 'store2'
 import { injectable } from 'tsyringe'
 
 import { catchError } from '@/knife'
+import { getLocale } from '@umijs/max'
 
 import type { Response } from '@/types'
+
 
 @injectable()
 export default class Index {
 	@catchError()
 	getAppInfo<Res>() {
 		const sid = nanoid() + new Date().valueOf()
-		const lang = window.navigator.language.toLowerCase()
+		const lang = getLocale()
 		const time = new Date().toLocaleString().replaceAll('/', '-')
 
 		store.set('temp_sid', sid)


### PR DESCRIPTION
如果从浏览器获取语言信息，当系统语言为英文时，无法正确切换语言包