### PR TITLE
add hidePagination param to enable edit/Table can display pagination

### DIFF
--- a/packages/xgen/components/edit/Table/index.tsx
+++ b/packages/xgen/components/edit/Table/index.tsx
@@ -10,17 +10,18 @@ import type { Component } from '@/types'
 interface IProps extends Component.PropsEditComponent {
 	model: IPropsTable['model']
 	query: IPropsTable['query']
+	hidePagination: IPropsTable['hidePagination']
 	itemProps?: { label?: string }
 }
 
 const Index = (props: IProps) => {
-	const { __name, itemProps, model, query } = props
+	const { __name, itemProps, model, query, hidePagination } = props
 
 	const props_table: IPropsTable = {
 		parent: 'Form',
 		model,
 		query: query ? query : {},
-		hidePagination: true
+		hidePagination: hidePagination
 	}
 
 	return (


### PR DESCRIPTION
Now the xgen component edit/Table can not display pagination, but sometimes we need the pagination, e.g. for a `model` which has many `fields`, if I want to show all fields in `model` form when no pagination, I have to specify a large search page_size,

```code
"字段表": {
  "edit": {
    "type": "Table",
    "props": {
      "model": "field",
      "query": { "where.model_id.eq": "{{id}}" }
    }
  }
}
```

after add pagination param, then the embed edit `fields` Table will show pagination, if you want to hide the pagination, you can add `"hidePagination": true`

```code
"字段表": {
  "edit": {
    "type": "Table",
    "props": {
      "model": "field",
      "query": { "where.model_id.eq": "{{id}}" },
      "hidePagination": true
    }
  }
}
```